### PR TITLE
getPrompt deletePrompt function added and GetPlate-DeleteVehicle exports

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -239,7 +239,19 @@ exports('SpawnVehicle', function(model, cb, coords, isnetworked)
     end
 end)
 
+exports('GetPlate',function(vehicle)
+    if vehicle == 0 then return end
+    return exports['qbr-core']:Trim(Citizen.InvokeNative(0xE8522D58,vehicle))
+end)
 
+exports("DeleteVehicle",function(vehicle)
+    SetEntityAsMissionEntity(vehicle, true, true)
+    DeleteVehicle(vehicle)
+end)
+
+
+
+-- Notification Function (can use direct export)
 -- Function for Progressbar ( Missing Function export )
 exports('Progressbar', function(name, label, duration, useWhileDead, canCancel, disableControls, animation, prop, propTwo, onFinish, onCancel)
     exports['progressbar']:Progress({
@@ -264,8 +276,6 @@ exports('Progressbar', function(name, label, duration, useWhileDead, canCancel, 
         end
     end)
 end)
-
--- Notification Function (can use direct export)
 
 local function LoadTexture(dict)
     if Citizen.InvokeNative(0x7332461FC59EB7EC, dict) then

--- a/client/prompts.lua
+++ b/client/prompts.lua
@@ -194,7 +194,7 @@ CreateThread(function()
         Wait(1)
         Citizen.InvokeNative(0xFC094EF26DD153FA, 1)
         Citizen.InvokeNative(0xFC094EF26DD153FA, 2)
-        --Citizen.InvokeNative(0xFC094EF26DD153FA, 3)
+        Citizen.InvokeNative(0xFC094EF26DD153FA, 3)
     end
 end)
 

--- a/client/prompts.lua
+++ b/client/prompts.lua
@@ -30,6 +30,36 @@ local function createPromptGroup(group, label, coords, prompts)
     end
 end
 
+local function getPrompt()
+    if Prompts then 
+    return Prompts
+    end
+end
+
+local function getPromptGroup()
+    if PromptGroups then 
+    return PromptGroups
+    end
+end
+
+
+local function deletePrompt(name)
+    if Prompts then
+        Citizen.InvokeNative(0x8A0FB4D03A630D21, Prompts[name].prompt, false)
+        Citizen.InvokeNative(0x71215ACCFDE075EE, Prompts[name].prompt, false)
+        Prompts[name] = nil
+    end
+end
+
+local function deletePromptGroup(name)
+    if PromptGroups then
+        Citizen.InvokeNative(0x8A0FB4D03A630D21, PromptGroups[name].prompt, false)
+        Citizen.InvokeNative(0x71215ACCFDE075EE, PromptGroups[name].prompt, false)
+        PromptGroups[name] = nil
+    end
+end
+
+
 local function executeOptions(options)
     if (options.type == 'client') then
         if (options.args == nil) then
@@ -164,9 +194,14 @@ CreateThread(function()
         Wait(1)
         Citizen.InvokeNative(0xFC094EF26DD153FA, 1)
         Citizen.InvokeNative(0xFC094EF26DD153FA, 2)
-        Citizen.InvokeNative(0xFC094EF26DD153FA, 3)
+        --Citizen.InvokeNative(0xFC094EF26DD153FA, 3)
     end
 end)
 
+
 exports('createPrompt', createPrompt)
 exports('createPromptGroup', createPromptGroup)
+exports('getPrompt', getPrompt)
+exports('getPromptGroup',getPromptGroup)
+exports('deletePrompt', deletePrompt)
+exports('deletePromptGroup',deletePromptGroup)


### PR DESCRIPTION
getPrompt deletePrompt function added

Why we need function ? 
- Sometimes you may need to delete your scripts when you restart or in development. In any case, you may need to remove it. That's why we add these functions.
- Since this usage is memorized, changes in your script are not deleted from memory(Prompts object in qbr-core). Therefore, when restarting your script, you can reset these values ​​or delete and re-create them.
- We can also delete and re-add them depending on the circumstances. Namely, we were able to delete and re-create areas in the polyzone. This like can thought of as well.
