### PR TITLE
Update events.lua

### DIFF
--- a/server/events.lua
+++ b/server/events.lua
@@ -1,9 +1,11 @@
 -- Event Handler
+GlobalState['Count:Players'] = 0
 
 AddEventHandler('playerDropped', function()
     local src = source
-    if not QBCore.Players[src] then return end
     local Player = QBCore.Players[src]
+    GlobalState['Count:Players'] = GetNumPlayerIndices()
+    if not Player then return end
     TriggerEvent('qb-log:server:CreateLog', 'joinleave', 'Dropped', 'red', '**' .. GetPlayerName(src) .. '** (' .. Player.PlayerData.license .. ') left..')
     Player.Functions.Save()
     QBCore.Players[src] = nil
@@ -87,6 +89,7 @@ local function OnPlayerConnecting(name, setKickReason, deferrals)
     elseif isLicenseAlreadyInUse then
         deferrals.done('Duplicate Rockstar License Found')
     else
+        GlobalState['Count:Players'] = GetNumPlayerIndices() + 1
         deferrals.done()
         if QBConfig.UseConnectQueue then
             Wait(1000)


### PR DESCRIPTION
This is Getting the Count of Players Using the GlobalState['Count:Players'] this is really helpful to add to scripts and pull the data without the need to loop if using StateBagChangeHandler as well as not needing to go to Server to get the player count. Been Using this for a while and is very useful. I also use this same concept for Job OnDuty Count as well for example GlobalState['Count:Police']. Will do a PR on that as well in future.